### PR TITLE
Bump openjdk base image version

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -30,7 +30,7 @@ object Settings {
       mainClass in Compile := Some("com.psisoyev.train.station.Main"),
       addCompilerPlugin(contextApplied),
       addCompilerPlugin(kindProjector),
-      dockerBaseImage := "openjdk:jre-alpine",
+      dockerBaseImage := "openjdk:11-jre",
       dockerUpdateLatest := true
     )
 


### PR DESCRIPTION
It is hard to find JDK 1.8.0_171 to compile compatible version. Actually, Debian 11 does not even have JDK 8 by default. So it seems better to migrate onto newer Java version.

Since there are no integration autotests, I checked this locally, it seems to be working.